### PR TITLE
Fix wrong link url

### DIFF
--- a/api/javascript/ui/menu.md
+++ b/api/javascript/ui/menu.md
@@ -6,7 +6,7 @@ description: How to configure all animations in Menu UI widget, enable and disab
 
 # kendo.ui.Menu
 
-Represents the Kendo UI Menu widget. Inherits from [Widget](/api/framework/widget).
+Represents the Kendo UI Menu widget. Inherits from [Widget](/api/javascript/ui/widget).
 
 ## Configuration
 


### PR DESCRIPTION
Correct widget link from `/api/framework/widget` to `/api/javascript/ui/widget`